### PR TITLE
Added a quick offset to where the camera starts when a ship is launched

### DIFF
--- a/Assets/Scripts/Prototype/FlightControl/SetupRocketOnLoad.cs
+++ b/Assets/Scripts/Prototype/FlightControl/SetupRocketOnLoad.cs
@@ -63,5 +63,8 @@ public class SetupRocketOnLoad : MonoBehaviour
         var cameraTarget = new CameraTarget();
         cameraTarget.TrackingTarget = _rocket.transform;
         camera.Target = cameraTarget;
+
+        var composer = this.gameObject.GetComponent<CinemachineOrbitalFollow>();
+        composer.TargetOffset = new Vector3(60, 0);
     }
 }


### PR DESCRIPTION
The new parts were much bigger than the original placeholder parts. Leaving the camera starting in an awkward position.

I'm still working on camera controls that would mitigate this. But in the mean time I opted for a quick fix to the camera by offsetting the camera back a bit so we can at least see more of the ship we launch.